### PR TITLE
Suggestions regarding tests and includes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,7 @@ uuid = "127a102c-159b-48d6-87e1-a656ac5f01e7"
 authors = ["Rafael Martinelli <martinelli@puc-rio.br>"]
 version = "0.1.0"
 
-[deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-
 [compat]
-Documenter = "0.26"
 julia = "1"
 
 [extras]

--- a/src/CARPData.jl
+++ b/src/CARPData.jl
@@ -6,6 +6,9 @@ export Data, Vertex, Edge, load, isRequired
 
 const data_path = joinpath(pkgdir(CARPData), "data")
 
+include("Vertex.jl")
+include("Edge.jl")
+include("Data.jl")
 include("Loader.jl")
 include("Util.jl")
 

--- a/src/Data.jl
+++ b/src/Data.jl
@@ -1,6 +1,3 @@
-include("Vertex.jl")
-include("Edge.jl")
-
 struct Data
     name::String
 

--- a/src/Loader.jl
+++ b/src/Loader.jl
@@ -1,5 +1,3 @@
-include("Data.jl")
-
 function load(instance::Symbol)
     instance = replace(string(instance), "_" => "-")
     file_name = joinpath(data_path, instance * ".dat")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,4 +74,16 @@ end
 @testset "Load string" begin
     data = load(joinpath(@__DIR__, "../data/kshs1.dat"))
     @test data !== nothing
+    data = load("not a file")
+    @test data === nothing
+end
+
+@testset "Base.show methods" begin
+    data = load(:kshs3)
+    show(stderr, data)
+    print("\n")
+    show(stderr, data.edges[1])
+    print("\n")
+    show(stderr, data.vertices[1])
+    print("\n")
 end


### PR DESCRIPTION
These are some suggestions regarding the tests and main file structure usually seen in other Julia packages.

1 - The package does not depend on Documenter. Usually when building docs you have a separate Project.toml file just for docs i.e. https://github.com/jump-dev/MathOptInterface.jl/tree/master/docs
2 - Usually all the includes are in the package main file
3 - One way to "test" the prints is by calling show and asserting that there is no error. This is a more relaxed test than asserting the content on the strings but I think it is enough.